### PR TITLE
Add outputs for Kubernetes cluster token and CA certificate, fix auto_scale

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -31,7 +31,7 @@ resource "digitalocean_kubernetes_cluster" "main" {
     content {
       name       = lookup(node_pool.value, "name", "critical")
       size       = lookup(node_pool.value, "size", "s-1vcpu-2gb")
-      node_count = lookup(node_pool.value, "auto_scale", true) ? null : lookup(node_pool.value, "node_count", 1)
+      node_count = lookup(node_pool.value, "auto_scale", true) ? null : lookup(each.value, "node_count", 1)
       auto_scale = lookup(node_pool.value, "auto_scale", true)
       min_nodes  = lookup(node_pool.value, "min_nodes", 1)
       max_nodes  = lookup(node_pool.value, "max_nodes", 2)
@@ -66,7 +66,7 @@ resource "digitalocean_kubernetes_node_pool" "main" {
   cluster_id = join("", digitalocean_kubernetes_cluster.main[*].id)
   name       = lookup(each.value, "name", "application")
   size       = lookup(each.value, "size", "s-1vcpu-2gb")
-  node_count = lookup(node_pool.value, "auto_scale", true) ? null : lookup(node_pool.value, "node_count", 1)
+  node_count = lookup(each.value, "auto_scale", true) ? null : lookup(each.value, "node_count", 1)
   auto_scale = lookup(each.value, "auto_scale", true)
   min_nodes  = lookup(each.value, "min_nodes", 1)
   max_nodes  = lookup(each.value, "max_nodes", 2)

--- a/main.tf
+++ b/main.tf
@@ -31,7 +31,7 @@ resource "digitalocean_kubernetes_cluster" "main" {
     content {
       name       = lookup(node_pool.value, "name", "critical")
       size       = lookup(node_pool.value, "size", "s-1vcpu-2gb")
-      node_count = lookup(node_pool.value, "node_count", 1)
+      node_count = lookup(node_pool.value, "auto_scale", true) ? null : lookup(node_pool.value, "node_count", 1)
       auto_scale = lookup(node_pool.value, "auto_scale", true)
       min_nodes  = lookup(node_pool.value, "min_nodes", 1)
       max_nodes  = lookup(node_pool.value, "max_nodes", 2)
@@ -66,7 +66,7 @@ resource "digitalocean_kubernetes_node_pool" "main" {
   cluster_id = join("", digitalocean_kubernetes_cluster.main[*].id)
   name       = lookup(each.value, "name", "application")
   size       = lookup(each.value, "size", "s-1vcpu-2gb")
-  node_count = lookup(each.value, "node_count", 1)
+  node_count = lookup(node_pool.value, "auto_scale", true) ? null : lookup(node_pool.value, "node_count", 1)
   auto_scale = lookup(each.value, "auto_scale", true)
   min_nodes  = lookup(each.value, "min_nodes", 1)
   max_nodes  = lookup(each.value, "max_nodes", 2)

--- a/main.tf
+++ b/main.tf
@@ -31,7 +31,7 @@ resource "digitalocean_kubernetes_cluster" "main" {
     content {
       name       = lookup(node_pool.value, "name", "critical")
       size       = lookup(node_pool.value, "size", "s-1vcpu-2gb")
-      node_count = lookup(node_pool.value, "auto_scale", true) ? null : lookup(each.value, "node_count", 1)
+      node_count = lookup(node_pool.value, "auto_scale", true) ? null : lookup(node_pool.value, "node_count", 1)
       auto_scale = lookup(node_pool.value, "auto_scale", true)
       min_nodes  = lookup(node_pool.value, "min_nodes", 1)
       max_nodes  = lookup(node_pool.value, "max_nodes", 2)

--- a/outputs.tf
+++ b/outputs.tf
@@ -52,3 +52,13 @@ output "maintenance_policy_day" {
 output "local_file" {
   value = join("", digitalocean_kubernetes_cluster.main[*].kube_config[0].raw_config)
 }
+
+output "token" {
+  value       = digitalocean_kubernetes_cluster.main[*].kube_config[0].token
+  description = "The token used to authenticate with the cluster."
+}
+
+output "cluster_ca_certificate" {
+  value       = digitalocean_kubernetes_cluster.main[*].kube_config[0].cluster_ca_certificate
+  description = "The certificate authority used to verify the cluster's API server."
+}

--- a/variables.tf
+++ b/variables.tf
@@ -38,7 +38,7 @@ variable "region" {
 
 variable "cluster_version" {
   type        = string
-  default     = "1.27.2"
+  default     = "1.31.1-do.5"
   description = "K8s Cluster Version."
 }
 


### PR DESCRIPTION

## what
Add outputs for Kubernetes cluster token and CA certificate. Fix auto_scale issue where node_count isn't needed if auto_scale is set.

## why

These outputs can be used as inputs to the k8s and helm terraform providers directly

If trying to use auto_scale and node pool has scaled away from the node_count, terraform will set node pool back to node_count which we don't want.

