### PR TITLE
Fix using sensitive outputs from digitalocean_kubernetes_cluster reso…

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -50,15 +50,18 @@ output "maintenance_policy_day" {
   description = "A block representing the cluster's maintenance window. Updates will be applied within this window."
 }
 output "local_file" {
-  value = join("", digitalocean_kubernetes_cluster.main[*].kube_config[0].raw_config)
+  value     = join("", digitalocean_kubernetes_cluster.main[*].kube_config[0].raw_config)
+  sensitive = true
 }
 
 output "token" {
   value       = digitalocean_kubernetes_cluster.main[*].kube_config[0].token
   description = "The token used to authenticate with the cluster."
+  sensitive   = true
 }
 
 output "cluster_ca_certificate" {
   value       = digitalocean_kubernetes_cluster.main[*].kube_config[0].cluster_ca_certificate
   description = "The certificate authority used to verify the cluster's API server."
+  sensitive   = true
 }


### PR DESCRIPTION
This is to fix terraform errors when using the module:
```

 ╷
  │ Error: Output refers to sensitive values
  │
  │   on outputs.tf line 53:
  │   53: output "local_file" {
  │
  │ To reduce the risk of accidentally exporting sensitive data that was
  │ intended to be only internal, Terraform requires that any root module
  │ output containing sensitive data be explicitly marked as sensitive, to
  │ confirm your intent.
  │
  │ If you do intend to export this data, annotate the output value as
  │ sensitive by adding the following argument:
  │     sensitive = true
  ╵
  ╷
  │ Error: Output refers to sensitive values
  │
  │   on outputs.tf line 57:
  │   57: output "token" {
  │
  │ To reduce the risk of accidentally exporting sensitive data that was
  │ intended to be only internal, Terraform requires that any root module
  │ output containing sensitive data be explicitly marked as sensitive, to
  │ confirm your intent.
  │
  │ If you do intend to export this data, annotate the output value as
  │ sensitive by adding the following argument:
  │     sensitive = true
  ╵
  ╷
  │ Error: Output refers to sensitive values
  │
  │   on outputs.tf line 62:
  │   62: output "cluster_ca_certificate" {
  │
  │ To reduce the risk of accidentally exporting sensitive data that was
  │ intended to be only internal, Terraform requires that any root module
  │ output containing sensitive data be explicitly marked as sensitive, to
  │ confirm your intent.
  │
  │ If you do intend to export this data, annotate the output value as
  │ sensitive by adding the following argument:
  │     sensitive = true
  ╵

  exit status 1
```