### PR TITLE
feat: harden workflows for day 15 using stf checks

### DIFF
--- a/.github/workflows/tf-checks.yml
+++ b/.github/workflows/tf-checks.yml
@@ -6,12 +6,14 @@ on:
   workflow_dispatch:
 jobs:
   basic-example:
-    uses: clouddrove/github-shared-workflows/.github/workflows/tf-checks.yml@88efd7724e007c8f721a219498be29e0c9ad471b # pinned to latest
+    uses: clouddrove/github-shared-workflows/.github/workflows/stf-checks.yml@c615ea7ef3e5beba98a335bf9acce8e67e03c755 # pinned to latest
     with:
+      provider: digitalocean
       working_directory: './_examples/basic/'
   complete-example:
-    uses: clouddrove/github-shared-workflows/.github/workflows/tf-checks.yml@88efd7724e007c8f721a219498be29e0c9ad471b # pinned to latest
+    uses: clouddrove/github-shared-workflows/.github/workflows/stf-checks.yml@c615ea7ef3e5beba98a335bf9acce8e67e03c755 # pinned to latest
     with:
+      provider: digitalocean
       working_directory: './_examples/complete/'
 
 # Seperate Job for TFlint workflow call


### PR DESCRIPTION
## Summary
- Day 15 implementation for Project #2: `terraform-digitalocean-kubernetes`.
- Switched reusable workflow call(s) from `tf-checks.yml` to `stf-checks.yml`.
- Added explicit `provider: digitalocean` for STF job inputs.
- Reusable workflow sources remain restricted to `clouddrove/github-shared-workflows` only.

## Ticket Mapping
- Project: `anmolnagpal` Project #2
- Ticket: **Day 15: Harden terraform-digitalocean-kubernetes defaults + examples**

## Checklist
- [x] Implementation branch created
- [x] Workflow updated to STF checks
- [x] Provider input set to digitalocean
- [x] PR opened and linked to board ticket
- [x] All required checks green
- [x] No merge performed