### PR TITLE
feat: Add SOC2-oriented Kubernetes baseline example

### DIFF
--- a/.github/workflows/tf-checks.yml
+++ b/.github/workflows/tf-checks.yml
@@ -16,6 +16,12 @@ jobs:
       provider: digitalocean
       working_directory: './_examples/complete/'
 
+  soc2-baseline-example:
+    uses: clouddrove/github-shared-workflows/.github/workflows/stf-checks.yml@c615ea7ef3e5beba98a335bf9acce8e67e03c755 # pinned to latest
+    with:
+      provider: digitalocean
+      working_directory: './_examples/soc2-baseline/'
+
 # Seperate Job for TFlint workflow call
   tf-lint:
     uses: clouddrove/github-shared-workflows/.github/workflows/tf-lint.yml@88efd7724e007c8f721a219498be29e0c9ad471b # pinned to latest

--- a/_examples/soc2-baseline/README.md
+++ b/_examples/soc2-baseline/README.md
@@ -1,0 +1,29 @@
+# SOC2 Baseline Example (DigitalOcean Kubernetes)
+
+This example provides a **SOC2-oriented baseline** for the Kubernetes module.
+It focuses on controlled operations, separation of critical/application pools,
+and evidence-friendly tagging.
+
+## Included baseline choices
+- HA control plane enabled (`ha = true`)
+- Manual, controlled upgrade posture (`auto_upgrade = false`, `surge_upgrade = false`)
+- Defined maintenance window
+- Dedicated critical + application node pools
+- Evidence and ownership tags for audit traceability
+
+## Important
+This is a **technical baseline**, not SOC2 certification by itself.
+You still need org controls and evidence for:
+- Access reviews and least privilege
+- Change management approvals
+- Centralized audit-log retention and review
+- Backup/restore testing cadence
+- Incident response runbooks and drills
+
+## Usage
+```bash
+cd _examples/soc2-baseline
+terraform init
+terraform plan
+terraform apply
+```

--- a/_examples/soc2-baseline/main.tf
+++ b/_examples/soc2-baseline/main.tf
@@ -1,0 +1,70 @@
+provider "digitalocean" {}
+
+locals {
+  name        = "platform"
+  environment = "prod"
+  region      = "blr1"
+}
+
+module "vpc" {
+  source      = "terraform-do-modules/vpc/digitalocean"
+  version     = "1.0.0"
+  name        = local.name
+  environment = local.environment
+  region      = local.region
+  ip_range    = "10.30.0.0/16"
+}
+
+module "cluster" {
+  source      = "./../../"
+  name        = local.name
+  environment = local.environment
+  region      = local.region
+
+  # Keep pinned and upgraded through controlled rollout waves.
+  cluster_version = "1.31.1-do.5"
+
+  vpc_uuid              = module.vpc.id
+  ha                    = true
+  auto_upgrade          = false
+  surge_upgrade         = false
+  registry_integration  = false
+  maintenance_policy = {
+    day        = "sunday"
+    start_time = "03:00"
+  }
+
+  tags = [
+    "env:prod",
+    "control:soc2-baseline",
+    "owner:platform",
+    "evidence:required"
+  ]
+
+  critical_node_pool = {
+    critical_node = {
+      node_count = 3
+      min_nodes  = 3
+      max_nodes  = 6
+      size       = "s-2vcpu-4gb"
+      labels     = { tier = "critical" }
+      tags       = ["critical", "soc2"]
+      taint = [{
+        key    = "tier"
+        value  = "critical"
+        effect = "NoSchedule"
+      }]
+    }
+  }
+
+  app_node_pools = {
+    app_node = {
+      node_count = 2
+      min_nodes  = 2
+      max_nodes  = 10
+      size       = "s-2vcpu-4gb"
+      labels     = { tier = "application" }
+      tags       = ["application", "soc2"]
+    }
+  }
+}

--- a/_examples/soc2-baseline/outputs.tf
+++ b/_examples/soc2-baseline/outputs.tf
@@ -1,14 +1,9 @@
-output "cluster_name" {
-  description = "Kubernetes cluster name"
-  value       = module.cluster.cluster_name
+output "cluster_id" {
+  description = "Kubernetes cluster ID"
+  value       = module.cluster.id
 }
 
 output "cluster_endpoint" {
   description = "Kubernetes API endpoint"
-  value       = module.cluster.cluster_endpoint
-}
-
-output "cluster_id" {
-  description = "Kubernetes cluster ID"
-  value       = module.cluster.cluster_id
+  value       = module.cluster.endpoint
 }

--- a/_examples/soc2-baseline/outputs.tf
+++ b/_examples/soc2-baseline/outputs.tf
@@ -1,0 +1,14 @@
+output "cluster_name" {
+  description = "Kubernetes cluster name"
+  value       = module.cluster.cluster_name
+}
+
+output "cluster_endpoint" {
+  description = "Kubernetes API endpoint"
+  value       = module.cluster.cluster_endpoint
+}
+
+output "cluster_id" {
+  description = "Kubernetes cluster ID"
+  value       = module.cluster.cluster_id
+}

--- a/_examples/soc2-baseline/versions.tf
+++ b/_examples/soc2-baseline/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.4"
+
+  required_providers {
+    digitalocean = {
+      source  = "digitalocean/digitalocean"
+      version = ">= 2.45.0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Added new example: `_examples/soc2-baseline/`
  - `main.tf`
  - `outputs.tf`
  - `versions.tf`
  - `README.md`
- Added tf-check workflow job for new example path

## What this baseline demonstrates
- HA control plane enabled
- Controlled upgrade posture (manual wave-ready)
- Defined maintenance window
- Critical vs application node-pool separation
- Audit/evidence-friendly tagging conventions

## Notes
- This is a technical baseline and does not claim certification by itself.
- README includes explicit manual controls still required for SOC2 readiness.
